### PR TITLE
rename signer to buyer for swap requests

### DIFF
--- a/src/Types.ts
+++ b/src/Types.ts
@@ -334,7 +334,7 @@ export interface MarketSwapExactInputRequest {
   tokenInAmount: BigIntish
   feePercent: BigIntish
   feeMinTokenOut: BigIntish
-  signer?: string
+  buyer?: string
   gasPrice?: BigIntish
   include?: SwapRequestInclude[]
 }
@@ -349,7 +349,7 @@ export interface MarketSwapExactOutputRequest {
   tokenInAmount: BigIntish
   feePercent: BigIntish
   feeMinTokenOut: BigIntish
-  signer?: string
+  buyer?: string
   gasPrice?: BigIntish
   include?: SwapRequestInclude[]
 }
@@ -363,7 +363,7 @@ export interface LimitSwapExactInputRequest {
 	tokenOut: TokenArgs
   tokenInAmount: BigIntish
   priceCurve: OracleJSON
-  signer: string
+  buyer?: string
   gasPrice?: BigIntish
   include?: SwapRequestInclude[]
 }
@@ -377,7 +377,7 @@ export interface LimitSwapExactOutputRequest {
 	tokenOut: TokenArgs
   tokenOutAmount: BigIntish
   priceCurve: OracleJSON
-  signer: string
+  buyer?: string
   gasPrice?: BigIntish
   include?: SwapRequestInclude[]
 }


### PR DESCRIPTION
and make the buyer param optional. These will only be needed if routes include is requested. The request does not have to be for the "signer", it can be for any address or contract that could be used for routing request, which is why we are changing the name to "buyer"